### PR TITLE
Performance improvements

### DIFF
--- a/screen.css
+++ b/screen.css
@@ -62,8 +62,8 @@
 }
 
 html {
-  height: 100%;
-  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 a {
@@ -251,8 +251,5 @@ body > * {
 #background {
   position: fixed;
   top: 0;
-  /*bottom: 0;*/
-  width: 100%;
   z-index: 0;
 }
-


### PR DESCRIPTION
- Only set #background[style.postion='absolute'] once.
- Reduce DOM access/calculation for scrolling.
- Disable background opacity transition during scroll.
- Use el.style instead of el.setAttribute('style') for translateY
- Use +new Date instead of new Date().getTime()
- Resize background manually, as width: 100% was causing uneccessary repaints.
- Use margin/padding: 0 instead of width/height: 100% for html CSS rule.

Would also benefit from removing the Twitter iframe, but have left that up to you :) Hope it helps!
