### PR TITLE
Adding Keystone / MongoDB workshop to TOC

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,6 +496,7 @@
             <li><a href="#nodeschool-functional-javascript">Functional JavaScript</a></li>
             <li><a href="#firefoxos-homescreen">Firefox OS Homescreen hacking</a></li>
             <li><a href="#atom-editor">Extending Atom editor</a></li>
+            <li><a name="#keystonejs-mongodb">Developing apps with KeystoneJS &amp; MongoDB</a></li>
           </ul>
           <h4>More to be announced...</h4>
 


### PR DESCRIPTION
Forgot to include the Keystone / MongoDB workshop in the TOC when I added it
