### PR TITLE
Fix speakers/mentors layout on very narrow screens

### DIFF
--- a/screen.css
+++ b/screen.css
@@ -533,3 +533,9 @@ body > .wrap {
   font-size: smaller;
   clear: both;
 }
+
+@media (max-width: 420px) {
+  .col-xs-6 {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
Mentor avatars were overlapping on narrow screens (e.g. iPhone in vertical configuration). This forces them to a single column instead.
